### PR TITLE
build: update dependencies and add ansible roles for settings and wazuh agent

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+---
+exclude_paths:
+  - .terragrunt-cache
+  - infra/
+  - packer/
+  - cli/

--- a/ansible/roles/settings_updates/README.md
+++ b/ansible/roles/settings_updates/README.md
@@ -18,6 +18,11 @@ Install Windows updates on managed hosts
 - **Enable update service** (ansible.windows.win_service)
 - **Install all updates and reboot as many times as needed** (ansible.windows.win_updates)
 
+### main.yml
+
+- **Enable update service** (ansible.windows.win_service)
+- **Install all updates and reboot as many times as needed** (ansible.windows.win_updates)
+
 ## Example Playbook
 
 ```yaml

--- a/ansible/roles/settings_updates/tasks/main.yml
+++ b/ansible/roles/settings_updates/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Enable update service
+  ansible.windows.win_service:
+    name: Windows Update
+    state: started
+    start_mode: auto
+
+- name: Install all updates and reboot as many times as needed
+  ansible.windows.win_updates:
+    category_names: '*'
+    reboot: true

--- a/ansible/roles/wazuh_agent_linux/README.md
+++ b/ansible/roles/wazuh_agent_linux/README.md
@@ -13,6 +13,16 @@ Install Wazuh agent on Linux hosts
 
 ## Tasks
 
+### main.yml
+
+- **Add Wazuh GPG key** (ansible.builtin.rpm_key) - Conditional
+- **Add Wazuh APT key** (ansible.builtin.apt_key) - Conditional
+- **Add Wazuh repository (Debian/Ubuntu)** (ansible.builtin.apt_repository) - Conditional
+- **Add Wazuh repository (RHEL/CentOS)** (ansible.builtin.yum_repository) - Conditional
+- **Install Wazuh agent** (ansible.builtin.package)
+- **Configure Wazuh agent manager address** (ansible.builtin.lineinfile)
+- **Enable and start Wazuh agent** (ansible.builtin.systemd)
+
 ## Example Playbook
 
 ```yaml

--- a/ansible/roles/wazuh_agent_linux/tasks/main.yml
+++ b/ansible/roles/wazuh_agent_linux/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Add Wazuh GPG key
+  ansible.builtin.rpm_key:
+    key: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Add Wazuh APT key
+  ansible.builtin.apt_key:
+    url: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Add Wazuh repository (Debian/Ubuntu)
+  ansible.builtin.apt_repository:
+    repo: "deb https://packages.wazuh.com/4.x/apt/ stable main"
+    state: present
+    filename: wazuh
+  when: ansible_os_family == "Debian"
+
+- name: Add Wazuh repository (RHEL/CentOS)
+  ansible.builtin.yum_repository:
+    name: wazuh
+    description: Wazuh repository
+    baseurl: https://packages.wazuh.com/4.x/yum/
+    gpgcheck: true
+    gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    enabled: true
+  when: ansible_os_family == "RedHat"
+
+- name: Install Wazuh agent
+  ansible.builtin.package:
+    name: wazuh-agent
+    state: present
+  environment:
+    WAZUH_MANAGER: "{{ wazuh_manager_host }}"
+
+- name: Configure Wazuh agent manager address
+  ansible.builtin.lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<address>.*</address>'
+    line: "      <address>{{ wazuh_manager_host }}</address>"
+
+- name: Enable and start Wazuh agent
+  ansible.builtin.systemd:
+    name: wazuh-agent
+    state: started
+    enabled: true


### PR DESCRIPTION

**Key Changes:**

- Added new Ansible roles for managing Windows updates and Wazuh agent on Linux
- Updated Go module dependencies and indirect requirements for broader compatibility
- Standardized Terragrunt runner logic to use `run --all` instead of `run-all`
- Changed environment variable for Terraform binary in Terragrunt runner

**Added:**

- Ansible Lint config to exclude certain directories from linting
- Ansible role to enable Windows Update service and install all updates with
  automatic reboots (`ansible/roles/settings_updates/tasks/main.yml`)
- Ansible role to install and configure the Wazuh agent on Linux, supporting
  both Debian and RedHat families (`ansible/roles/wazuh_agent_linux/tasks/main.yml`)
- Enhanced READMEs for both Ansible roles with detailed task descriptions

**Changed:**

- Updated Go module and sum files in `cli/`:
  - Added new dependencies (`github.com/cowdogmoo/warpgate/v3`, container/image
    libraries, and related indirects)
  - Updated versions of existing dependencies for security and compatibility
  - Added local `replace` for `github.com/cowdogmoo/warpgate/v3`
- Standardized Terragrunt runner logic:
  - Switched from `run-all` to `run --all` in both code and log messages for
    consistency with newer Terragrunt CLI
  - Updated comment and error message strings accordingly
  - Changed environment variable for specifying Terraform binary from
    `TERRAGRUNT_TFPATH` to `TG_TF_PATH` for compliance with updated conventions

**Removed:**

- Deprecated use of `run-all` argument and `TERRAGRUNT_TFPATH` env variable in
  Terragrunt runner, in favor of their modern alternatives