### PR TITLE
chore: auto-tidy go.sum and expand renovate automerge scope

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,9 @@
       '/(^|/)\\.hooks/requirements\\.txt$/',
     ],
   },
+  postUpdateOptions: [
+    'gomodTidy',
+  ],
   packageRules: [
     {
       description: 'Auto merge Galaxy dependencies',
@@ -87,6 +90,45 @@
       matchUpdateTypes: [
         'minor',
         'patch',
+      ],
+    },
+    {
+      description: 'Auto-merge Go module dependencies (minor/patch + digests)',
+      matchManagers: [
+        'gomod',
+      ],
+      automerge: true,
+      automergeType: 'pr',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+        'digest',
+      ],
+    },
+    {
+      description: 'Auto-merge Terraform providers and modules (minor/patch)',
+      matchManagers: [
+        'terraform',
+      ],
+      automerge: true,
+      automergeType: 'pr',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+    },
+    {
+      description: 'Auto-merge Docker base images (minor/patch + digests)',
+      matchManagers: [
+        'dockerfile',
+        'docker-compose',
+      ],
+      automerge: true,
+      automergeType: 'pr',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+        'digest',
       ],
     },
     {


### PR DESCRIPTION
**Key Changes:**

- Renovate now runs `go mod tidy` after every Go module update, eliminating the recurring pre-commit failure that blocked the merge queue on every gomod bump
- Added auto-merge for minor, patch, and digest updates across `gomod`, `terraform`, and `dockerfile`/`docker-compose` so routine dependency PRs no longer pile up waiting for manual clicks
- Major version bumps (e.g. `ubuntu 24 → 26`) still require human review and remain untouched

**Added:**

- Top-level `postUpdateOptions: ["gomodTidy"]` in `.github/renovate.json5` so Renovate Go-module PRs include a tidied `go.sum` at PR creation
- Auto-merge rule for the `gomod` manager covering `minor`, `patch`, and `digest` update types
- Auto-merge rule for the `terraform` manager covering `minor` and `patch` update types
- Auto-merge rule for the `dockerfile` and `docker-compose` managers covering `minor`, `patch`, and `digest` update types