### PR TITLE
feat: add .NET Framework version check and automated upgrade for PSPKI support

### DIFF
--- a/ansible/roles/vulns_adcs_esc7/README.md
+++ b/ansible/roles/vulns_adcs_esc7/README.md
@@ -15,6 +15,9 @@ ADCS ESC7 - Grant ManageCA rights for CA officer abuse
 
 ### main.yml
 
+- **Read installed .NET Framework release key** (ansible.windows.win_reg_stat)
+- **Install .NET Framework 4.8 (PSPKI 4.x requires >=4.7.2)** (chocolatey.chocolatey.win_chocolatey) - Conditional
+- **Reboot to complete .NET Framework upgrade** (ansible.windows.win_reboot) - Conditional
 - **Ensure NuGet provider is installed** (ansible.windows.win_shell)
 - **Install module PSPKI** (ansible.windows.win_powershell)
 - **ADD ManageCA rights** (ansible.windows.win_powershell)

--- a/ansible/roles/vulns_adcs_esc7/tasks/main.yml
+++ b/ansible/roles/vulns_adcs_esc7/tasks/main.yml
@@ -1,5 +1,26 @@
 # Code adapted from ludus adcs module : https://github.com/badsectorlabs/ludus_adcs/blob/main/files/esc7.ps1
 # RUN me on DC
+# PSPKI 4.x is built against .NET Framework 4.7.2 (uses System.Security.Cryptography.ECParameters,
+# introduced in 4.7). Server 2016 RTM ships with 4.6.2 and the 4.7+ upgrade is OOB, so Import-Module
+# PSPKI fails with ReflectionTypeLoadException on un-upgraded 2016 hosts.
+- name: Read installed .NET Framework release key
+  ansible.windows.win_reg_stat:
+    path: HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full
+    name: Release
+  register: _net_release
+
+- name: Install .NET Framework 4.8 (PSPKI 4.x requires >=4.7.2)
+  chocolatey.chocolatey.win_chocolatey:
+    name: dotnetfx
+    state: present
+  when: (_net_release.value | default(0) | int) < 461808
+  register: _dotnetfx_install
+
+- name: Reboot to complete .NET Framework upgrade
+  ansible.windows.win_reboot:
+    reboot_timeout: 1200
+  when: _dotnetfx_install is changed
+
 - name: Ensure NuGet provider is installed
   ansible.windows.win_shell: |
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -25,7 +46,21 @@
           [String]
           $caManagerUser
       )
-      Import-Module -Name PSPKI -ErrorAction Stop
+      try {
+          Import-Module -Name PSPKI -ErrorAction Stop
+      } catch {
+          # ReflectionTypeLoadException buries the actionable detail in LoaderExceptions.
+          # Surface it so future framework/assembly drift is self-diagnosing.
+          $rtle = $_.Exception
+          while ($rtle -and -not ($rtle -is [System.Reflection.ReflectionTypeLoadException])) {
+              $rtle = $rtle.InnerException
+          }
+          if ($rtle) {
+              $msgs = @($rtle.LoaderExceptions | ForEach-Object { $_.Message } | Select-Object -Unique)
+              throw "Import-Module PSPKI failed: $($_.Exception.Message). LoaderExceptions: $($msgs -join ' | ')"
+          }
+          throw
+      }
       $caHostname = Get-CertificationAuthority | Select-Object -ExpandProperty ComputerName
       $acl = Get-CertificationAuthority "$caHostname" | Get-CertificationAuthorityAcl
 


### PR DESCRIPTION
**Key Changes:**

- Added detection and conditional installation of .NET Framework 4.8
- Automated reboot if .NET upgrade is performed
- Improved error handling and diagnostics for PSPKI module import failures

**Added:**

- .NET Framework version check using registry query to determine installed version
- Conditional installation of .NET Framework 4.8 via Chocolatey if required for
  PSPKI compatibility
- Automated reboot task to finalize .NET upgrade only when installation occurs

**Changed:**

- Enhanced PSPKI import logic in PowerShell to catch
  ReflectionTypeLoadException, extract LoaderExceptions, and throw detailed
  errors for easier troubleshooting of framework or assembly issues