### PR TITLE
build: update goreleaser version and build matrix configuration

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           distribution: goreleaser
-          version: latest
-          args: release --clean
+          version: "~> v2"
+          args: release --clean --parallelism 2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,16 +25,7 @@ builds:
 
     goarch:
       - amd64
-      - arm
       - arm64
-
-    goarm:
-      - "6"
-      - "7"
-
-    goamd64:
-      - v2
-      - v3
 
     hooks:
       pre:


### PR DESCRIPTION
**Key Changes:**

- Updated GitHub Actions workflow to use Goreleaser v2 and set parallelism
- Simplified build matrix by removing goarm and goamd64 variants from Goreleaser config

**Changed:**

- GitHub Actions workflow - Pinned Goreleaser version to "~> v2" and added `--parallelism 2` to release command in `.github/workflows/goreleaser.yaml`
- Build matrix configuration - Removed `goarm` and `goamd64` specifications from `.goreleaser.yaml` to streamline target architectures

**Removed:**

- ARM build variants and goamd64 levels - Eliminated explicit `goarm` (6 and 7) and `goamd64` (v2, v3) definitions from build configuration