### PR TITLE
docs: update CLI docs and validation usage, add scoreboard keybindings, remove validate format flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Create a randomized copy of any lab with unique names but identical attack paths
 
 ## Documentation
 
-- [CLI configuration](docs/cli.md) -- Viper-based config, environment variables, per-environment settings
+- [CLI reference](docs/cli.md) -- command index plus Viper-based config, environment variables, and per-environment settings
 - [Domains and users](docs/domains-and-users.md) -- full network topology, credentials, and attack paths
 - [Vulnerability catalog](docs/GOAD-vulnerabilities-comprehensive.md) -- all 50+ vulnerabilities with exploitation techniques
 - [Validation guide](docs/validation.md) -- automated vulnerability validation (with live dashboard and polling)

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -26,7 +26,7 @@ xp_cmdshell, sysadmins), ADCS (templates), ACLs, trusts, SID filtering, schedule
 LLMNR/NBT-NS, GPO abuse, gMSA, LAPS, and services.`,
 	Example: `  dreadgoad validate
   dreadgoad validate --env staging --verbose
-  dreadgoad validate --format json --output /tmp/results.json
+  dreadgoad validate --output /tmp/results.json
   dreadgoad validate --no-fail
   dreadgoad validate --quick
   dreadgoad validate --plain        # disable the live dashboard
@@ -38,7 +38,6 @@ LLMNR/NBT-NS, GPO abuse, gMSA, LAPS, and services.`,
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().String("format", "table", "Output format: table or json")
 	validateCmd.Flags().String("output", "", "JSON report output path")
 	validateCmd.Flags().Bool("verbose", false, "Enable verbose output")
 	validateCmd.Flags().Bool("no-fail", false, "Don't exit with error on failed checks")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,34 @@
-# DreadGOAD CLI Configuration
+# DreadGOAD CLI Reference
+
+## Commands
+
+Run `dreadgoad <command> --help` for full flag listings. Major commands:
+
+| Command         | What it does                                                                                  |
+|-----------------|-----------------------------------------------------------------------------------------------|
+| `init`          | Interactive setup wizard — writes a ready-to-use `dreadgoad.yaml`                             |
+| `doctor`        | Pre-flight system checks (toolchain, credentials, project layout)                             |
+| `config`        | Manage CLI configuration (`init`, `show`, `set`, `get`) — see [Configuration](#configuration) |
+| `env`           | Manage deployment environments and per-env overlays                                           |
+| `infra`         | Plan/apply/destroy Terragrunt infrastructure                                                  |
+| `provision`     | Run GOAD provisioning playbooks with retry logic                                              |
+| `up`            | End-to-end deploy: `doctor` → `infra` → `provision` → `health-check`                          |
+| `lab`           | Manage lab lifecycle (`list`, `status`, `reset`, ...)                                         |
+| `inventory`     | Generate/inspect Ansible inventory                                                            |
+| `health-check`  | Verify all lab instances are reachable and healthy                                            |
+| `verify-trusts` | Verify domain trust relationships between all lab domains                                     |
+| `validate`      | Run vulnerability checks against the live lab — see [validation.md](./validation.md)          |
+| `scoreboard`    | Live engagement status board (answer key + agent report) — see [scoreboard.md](./scoreboard.md) |
+| `variant`       | Generate randomized graph-isomorphic lab variants                                             |
+| `extension`     | Manage pluggable lab extensions (ELK, Exchange, Wazuh, ...)                                   |
+| `ami`           | Build and manage golden AMIs (warpgate)                                                       |
+| `ssm`           | Manage AWS SSM sessions to lab hosts                                                          |
+| `bastion`       | Connect to lab VMs via Azure Bastion (SSH, RDP, port tunnel)                                  |
+| `runcmd`        | Run commands and open shells via Azure Run Command                                            |
+| `diagnose`      | Run diagnostic checks against domain controllers                                              |
+| `ad-users`      | Ensure AD users exist (runs `ad-data.yml`)                                                    |
+
+## Configuration
 
 The `dreadgoad` CLI uses [Viper](https://github.com/spf13/viper) for
 configuration, with values resolved in this priority order:

--- a/docs/scoreboard.md
+++ b/docs/scoreboard.md
@@ -54,6 +54,27 @@ key, and renders the live board.
 | `--restart`     | `false`                          | Delete the report file on the target before starting               |
 | `--once`        | `false`                          | Fetch and verify once, print the static board, exit (no TUI)       |
 
+### Keybindings
+
+The live TUI accepts the following keys (a subset is shown in the
+footer hint when the board is not in compact mode):
+
+| Key                       | Action                              |
+|---------------------------|-------------------------------------|
+| `q`, `ctrl+c`, `esc`      | Quit                                |
+| `r`                       | Force an immediate re-poll          |
+| `j` / `down`              | Scroll down one row                 |
+| `k` / `up`                | Scroll up one row                   |
+| `space`, `pgdown`, `ctrl+d` | Scroll down one page              |
+| `pgup`, `ctrl+u`          | Scroll up one page                  |
+| `g`, `home`               | Jump to top                         |
+| `G`, `end`                | Pin to bottom (follows new findings) |
+
+When the natural board layout would overflow the terminal height (e.g.
+running in a short tmux pane), the TUI automatically switches to a
+compact mode that drops blank spacers — the scroll keys above are how
+you reach content that is below the viewport.
+
 ### Transports
 
 - **`local`**: read a JSONL file from the host running the CLI. Best

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -8,11 +8,12 @@ are wired up correctly.
 ## Quick Start
 
 ```bash
-dreadgoad validate                # full validation, active env
-dreadgoad validate --env dev      # specific environment
-dreadgoad validate --quick        # critical vulnerabilities only
-dreadgoad validate --verbose      # extra per-check detail
-dreadgoad validate --no-fail      # always exit 0
+dreadgoad validate                       # full validation, active env
+dreadgoad validate --env dev             # specific environment
+dreadgoad validate --quick               # critical vulnerabilities only
+dreadgoad validate --verbose             # extra per-check detail
+dreadgoad validate --no-fail             # always exit 0
+dreadgoad validate --output report.json  # write JSON report to a custom path
 ```
 
 ### Live Dashboard
@@ -37,6 +38,10 @@ dreadgoad validate --poll 5m
 Keys: `q`, `ctrl+c`, or `esc` to quit. The JSON report on disk is the
 canonical record; it is rewritten at the end of each pass and the path is
 printed on exit.
+
+When the terminal is too short to fit the full layout (e.g. a short tmux
+pane), the dashboard automatically switches to a compact mode that drops
+blank spacers and the keyboard hint so the category grid stays visible.
 
 `--poll` requires the live dashboard (ignored with `--plain` or non-TTY).
 Intervals shorter than `1m` are rejected. Accepted "off" values: `never`,


### PR DESCRIPTION
**Key Changes:**

- Added comprehensive CLI command reference table to CLI documentation
- Documented live scoreboard TUI keybindings and compact mode behavior
- Updated validation usage examples to highlight JSON output and dashboard modes
- Removed deprecated `--format` flag from `validate` command

**Added:**

- CLI documentation now includes a detailed command table covering all major
  commands and their descriptions, improving discoverability for users
- Scoreboard documentation details supported TUI keybindings and explains
  compact mode for terminals with limited height

**Changed:**

- CLI documentation re-titled as "CLI Reference" and reorganized to include
  both commands and configuration sections for clarity
- Validation guide quick start examples updated to include `--output` flag for
  JSON reports, with improved formatting for readability
- Validation dashboard section expanded to clarify compact mode behavior when
  terminal height is limited

**Removed:**

- `--format` flag from the `validate` command to simplify usage and eliminate
  unsupported output options