### PR TITLE
feat: add instance_profile config field for EC2 Image Builder

### DIFF
--- a/cli/cmd/ami.go
+++ b/cli/cmd/ami.go
@@ -174,7 +174,7 @@ func runAMIBuild(cmd *cobra.Command, args []string) error {
 		region:          getFlagString(cmd, "region", cfg.Region, ""),
 		instanceType:    getFlagStringOpt(cmd, "instance-type"),
 		profile:         getFlagStringOpt(cmd, "profile"),
-		instanceProfile: getFlagStringOpt(cmd, "instance-profile"),
+		instanceProfile: getFlagString(cmd, "instance-profile", cfg.InstanceProfile, ""),
 		reuseResources:  getFlagBool(cmd, "reuse-resources"),
 	}
 

--- a/cli/cmd/ami_test.go
+++ b/cli/cmd/ami_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGetFlagString(t *testing.T) {
+	newCmd := func(flagVal string) *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("instance-profile", "", "")
+		if flagVal != "" {
+			if err := cmd.Flags().Set("instance-profile", flagVal); err != nil {
+				t.Fatalf("set flag: %v", err)
+			}
+		}
+		return cmd
+	}
+
+	tests := []struct {
+		name      string
+		flagVal   string
+		fallback1 string
+		fallback2 string
+		want      string
+	}{
+		{
+			name:      "flag wins over config fallback",
+			flagVal:   "FlagProfile",
+			fallback1: "ConfigProfile",
+			fallback2: "default",
+			want:      "FlagProfile",
+		},
+		{
+			name:      "config fallback used when flag empty",
+			flagVal:   "",
+			fallback1: "ConfigProfile",
+			fallback2: "default",
+			want:      "ConfigProfile",
+		},
+		{
+			name:      "second fallback when both flag and config empty",
+			flagVal:   "",
+			fallback1: "",
+			fallback2: "default",
+			want:      "default",
+		},
+		{
+			name:      "empty when all sources empty",
+			flagVal:   "",
+			fallback1: "",
+			fallback2: "",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newCmd(tt.flagVal)
+			got := getFlagString(cmd, "instance-profile", tt.fallback1, tt.fallback2)
+			if got != tt.want {
+				t.Errorf("getFlagString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -91,17 +91,17 @@ type Config struct {
 	Region          string                       `mapstructure:"region"`
 	InstanceProfile string                       `mapstructure:"instance_profile"`
 	Debug           bool                         `mapstructure:"debug"`
-	MaxRetries   int                          `mapstructure:"max_retries"`
-	RetryDelay   int                          `mapstructure:"retry_delay"`
-	IdleTimeout  int                          `mapstructure:"idle_timeout"`
-	LogDir       string                       `mapstructure:"log_dir"`
-	Playbooks    []string                     `mapstructure:"playbooks"`
-	ProjectRoot  string                       `mapstructure:"project_root"`
-	Environments map[string]EnvironmentConfig `mapstructure:"environments"`
-	Extensions   map[string]ExtensionConfig   `mapstructure:"extensions"`
-	Infra        InfraConfig                  `mapstructure:"infra"`
-	Proxmox      ProxmoxConfig                `mapstructure:"proxmox"`
-	Ludus        LudusConfig                  `mapstructure:"ludus"`
+	MaxRetries      int                          `mapstructure:"max_retries"`
+	RetryDelay      int                          `mapstructure:"retry_delay"`
+	IdleTimeout     int                          `mapstructure:"idle_timeout"`
+	LogDir          string                       `mapstructure:"log_dir"`
+	Playbooks       []string                     `mapstructure:"playbooks"`
+	ProjectRoot     string                       `mapstructure:"project_root"`
+	Environments    map[string]EnvironmentConfig `mapstructure:"environments"`
+	Extensions      map[string]ExtensionConfig   `mapstructure:"extensions"`
+	Infra           InfraConfig                  `mapstructure:"infra"`
+	Proxmox         ProxmoxConfig                `mapstructure:"proxmox"`
+	Ludus           LudusConfig                  `mapstructure:"ludus"`
 }
 
 var (

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -86,10 +86,11 @@ func (l LudusConfig) SSHTarget() string {
 
 // Config holds all CLI configuration.
 type Config struct {
-	Env          string                       `mapstructure:"env"`
-	Provider     string                       `mapstructure:"provider"`
-	Region       string                       `mapstructure:"region"`
-	Debug        bool                         `mapstructure:"debug"`
+	Env             string                       `mapstructure:"env"`
+	Provider        string                       `mapstructure:"provider"`
+	Region          string                       `mapstructure:"region"`
+	InstanceProfile string                       `mapstructure:"instance_profile"`
+	Debug           bool                         `mapstructure:"debug"`
 	MaxRetries   int                          `mapstructure:"max_retries"`
 	RetryDelay   int                          `mapstructure:"retry_delay"`
 	IdleTimeout  int                          `mapstructure:"idle_timeout"`

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -181,6 +182,36 @@ func TestLabConfigPath(t *testing.T) {
 		want := filepath.Join(dir, "ad", "GOAD", "data", "dev-config.json")
 		if got != want {
 			t.Errorf("LabConfigPath() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestConfigInstanceProfile(t *testing.T) {
+	t.Run("field accessible on struct", func(t *testing.T) {
+		c := &Config{InstanceProfile: "WarpgateImageBuilderInstanceProfile"}
+		if c.InstanceProfile != "WarpgateImageBuilderInstanceProfile" {
+			t.Errorf("InstanceProfile = %q, want %q", c.InstanceProfile, "WarpgateImageBuilderInstanceProfile")
+		}
+	})
+
+	t.Run("zero value is empty string", func(t *testing.T) {
+		c := &Config{}
+		if c.InstanceProfile != "" {
+			t.Errorf("InstanceProfile = %q, want empty", c.InstanceProfile)
+		}
+	})
+
+	t.Run("mapstructure tag is instance_profile", func(t *testing.T) {
+		// Verify the struct tag so viper unmarshals the YAML key correctly.
+		var c Config
+		typ := reflect.TypeOf(c)
+		f, ok := typ.FieldByName("InstanceProfile")
+		if !ok {
+			t.Fatal("Config struct missing InstanceProfile field")
+		}
+		tag := f.Tag.Get("mapstructure")
+		if tag != "instance_profile" {
+			t.Errorf("mapstructure tag = %q, want %q", tag, "instance_profile")
 		}
 	})
 }

--- a/cli/internal/config/defaults.go
+++ b/cli/internal/config/defaults.go
@@ -33,6 +33,7 @@ var RebootPlaybooks = []string{
 func setDefaults() {
 	viper.SetDefault("env", "staging")
 	viper.SetDefault("region", "")
+	viper.SetDefault("instance_profile", "")
 	viper.SetDefault("debug", false)
 	viper.SetDefault("max_retries", 3)
 	viper.SetDefault("retry_delay", 30)

--- a/dreadgoad.yaml
+++ b/dreadgoad.yaml
@@ -2,6 +2,7 @@
 env: staging
 provider: aws  # Provider: aws, proxmox, ludus
 # region: us-west-2  # Override AWS region (default: from inventory)
+instance_profile: WarpgateImageBuilderInstanceProfile  # IAM instance profile for EC2 Image Builder
 debug: false
 max_retries: 3
 retry_delay: 30


### PR DESCRIPTION
## Summary
- Add `InstanceProfile` field to `Config` struct with `mapstructure:"instance_profile"` tag
- Wire `ami build` to fall back to `cfg.InstanceProfile` via `getFlagString` (flag > config > empty)
- Add viper default and `dreadgoad.yaml` entry for `instance_profile`
- Add `TestConfigInstanceProfile` (struct field + mapstructure tag validation) and `TestGetFlagString` (4-case precedence table) in new `cmd/ami_test.go`

## Test plan
- [x] `go test ./internal/config/` — all pass
- [x] `go test ./cmd/` — all pass (including new `TestGetFlagString`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)