### PR TITLE
Fix macOS Ansible worker crashes from ObjC fork safety

### DIFF
--- a/cli/internal/ansible/runner.go
+++ b/cli/internal/ansible/runner.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -228,6 +229,16 @@ func buildArgs(opts RunOptions, cfg *config.Config) []string {
 
 func buildEnv(opts RunOptions, cfg *config.Config) ([]string, error) {
 	env := os.Environ()
+
+	// On macOS, the ObjC runtime aborts forked child processes when class
+	// initialisation is in progress at fork time.  Ansible forks workers
+	// heavily, which triggers:
+	//   "+[NSNumber initialize] may have been in progress in another thread
+	//    when fork() was called … Crashing instead."
+	// Setting this variable tells the runtime to skip the check.
+	if runtime.GOOS == "darwin" {
+		env = append(env, "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES")
+	}
 
 	ansibleEnv, err := cfg.AnsibleEnv()
 	if err != nil {


### PR DESCRIPTION
Ansible workers crash immediately on macOS with Python 3.14, aborting every playbook at the "Gathering Facts" stage with `+[NSNumber initialize] may have been in progress in another thread when fork() was called`.

## Fixed
- Ansible playbooks no longer crash on macOS with "A worker was found in a dead state" caused by the ObjC runtime killing forked Python processes during class initialisation
- `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` is now injected automatically into the Ansible subprocess environment on Darwin, so users don't need to export it manually