### PR TITLE
feat: add universal and missing ADCS techniques to scoreboard logic

### DIFF
--- a/ad/GOAD/data/config.json
+++ b/ad/GOAD/data/config.json
@@ -19,7 +19,7 @@
                 ]
             },
             "scripts" : ["sidhistory.ps1"],
-            "vulns" : ["disable_firewall", "adcs_esc10_case1", "adcs_esc10_case2"],
+            "vulns" : ["disable_firewall", "adcs_esc8", "adcs_esc10_case1", "adcs_esc10_case2"],
             "security": ["account_is_sensitive", "audit_policy"],
             "security_vars": {
                 "account_is_sensitive" : { "renly": {"account" : "renly.baratheon"} }
@@ -218,7 +218,7 @@
                 "essos\\Dothraki"
             ],
             "scripts" : [],
-            "vulns" : ["openshares","disable_firewall", "adcs_esc6", "adcs_esc11"],
+            "vulns" : ["openshares","disable_firewall", "adcs_esc6", "adcs_esc8", "adcs_esc11"],
             "security": ["enable_run_as_ppl"],
             "mssql":{
                 "sa_password": "sa_P@ssw0rd!Ess0s",

--- a/ad/GOAD/data/config.json
+++ b/ad/GOAD/data/config.json
@@ -19,7 +19,7 @@
                 ]
             },
             "scripts" : ["sidhistory.ps1"],
-            "vulns" : ["disable_firewall", "adcs_esc8", "adcs_esc10_case1", "adcs_esc10_case2"],
+            "vulns" : ["disable_firewall", "adcs_esc10_case1", "adcs_esc10_case2"],
             "security": ["account_is_sensitive", "audit_policy"],
             "security_vars": {
                 "account_is_sensitive" : { "renly": {"account" : "renly.baratheon"} }
@@ -218,7 +218,7 @@
                 "essos\\Dothraki"
             ],
             "scripts" : [],
-            "vulns" : ["openshares","disable_firewall", "adcs_esc6", "adcs_esc8", "adcs_esc11"],
+            "vulns" : ["openshares","disable_firewall", "adcs_esc6", "adcs_esc11"],
             "security": ["enable_run_as_ppl"],
             "mssql":{
                 "sa_password": "sa_P@ssw0rd!Ess0s",

--- a/cli/internal/scoreboard/generate.go
+++ b/cli/internal/scoreboard/generate.go
@@ -358,6 +358,7 @@ func extractTechniques(lab map[string]any, asrep map[string][]string) []Objectiv
 	addKerberosTechniques(domains, asrep, add)
 	addHostTechniques(hosts, add)
 	addDomainTechniques(domains, add)
+	addADCSWebEnrollmentTechnique(domains, add)
 	addUniversalTechniques(add)
 
 	keys := make([]string, 0, len(techniques))
@@ -496,6 +497,22 @@ func addPrivescTechniques(h map[string]any, add techniqueAdd) {
 		if strings.Contains(getStr(p, "user"), "IIS") {
 			add("seimpersonate", "SeImpersonate (Potato/PrintSpoofer)", "privilege_escalation")
 		}
+	}
+}
+
+// addADCSWebEnrollmentTechnique credits ESC8 when any domain has Web Enrollment
+// installed. ESC8 isn't a per-host vulns marker (Ansible would try to dispatch
+// a non-existent vulns_adcs_esc8 role) — it's gated by the domain-level
+// ca_web_enrollment flag, which defaults to true. Mirrors validate/checks.go's
+// CAWebEnrollment() logic.
+func addADCSWebEnrollmentTechnique(domains map[string]any, add techniqueAdd) {
+	for _, dRaw := range domains {
+		d, _ := dRaw.(map[string]any)
+		if v, ok := d["ca_web_enrollment"].(bool); ok && !v {
+			continue
+		}
+		add("adcs_esc8", "ADCS ESC8", "adcs")
+		return
 	}
 }
 

--- a/cli/internal/scoreboard/generate.go
+++ b/cli/internal/scoreboard/generate.go
@@ -315,13 +315,16 @@ var adcsLabels = map[string]string{
 	"adcs_esc2":        "ADCS ESC2",
 	"adcs_esc3":        "ADCS ESC3",
 	"adcs_esc4":        "ADCS ESC4",
+	"adcs_esc5":        "ADCS ESC5",
 	"adcs_esc6":        "ADCS ESC6",
 	"adcs_esc7":        "ADCS ESC7",
+	"adcs_esc8":        "ADCS ESC8",
 	"adcs_esc9":        "ADCS ESC9",
 	"adcs_esc10_case1": "ADCS ESC10 (Case 1)",
 	"adcs_esc10_case2": "ADCS ESC10 (Case 2)",
 	"adcs_esc11":       "ADCS ESC11",
 	"adcs_esc13":       "ADCS ESC13",
+	"adcs_esc14":       "ADCS ESC14",
 	"adcs_esc15":       "ADCS ESC15",
 }
 
@@ -355,7 +358,7 @@ func extractTechniques(lab map[string]any, asrep map[string][]string) []Objectiv
 	addKerberosTechniques(domains, asrep, add)
 	addHostTechniques(hosts, add)
 	addDomainTechniques(domains, add)
-	add("child_to_parent", "Child-to-Parent Domain Escalation", "domain_trust")
+	addUniversalTechniques(add)
 
 	keys := make([]string, 0, len(techniques))
 	for k := range techniques {
@@ -494,6 +497,24 @@ func addPrivescTechniques(h map[string]any, add techniqueAdd) {
 			add("seimpersonate", "SeImpersonate (Potato/PrintSpoofer)", "privilege_escalation")
 		}
 	}
+}
+
+// addUniversalTechniques credits techniques that are exploitable against any
+// default-configured GOAD lab: cross-domain escalation, unpatched DC CVEs,
+// ADCS-adjacent abuses (Certifried), IPv6 poisoning, and MAQ=10 chains. These
+// don't have per-host markers — the lab's defaults (unpatched Server roles,
+// MAQ=10, Print Spooler on, ca_web_enrollment=true) make them universally
+// applicable. Documented in docs/GOAD-vulnerabilities-comprehensive.md.
+func addUniversalTechniques(add techniqueAdd) {
+	add("child_to_parent", "Child-to-Parent Domain Escalation", "domain_trust")
+	add("nopac", "noPac (CVE-2021-42287/42278)", "cve")
+	add("printnightmare", "PrintNightmare (CVE-2021-1675)", "cve")
+	add("zerologon", "ZeroLogon (CVE-2020-1472)", "cve")
+	add("cve_2019_1040", "CVE-2019-1040 (Remove-MIC NTLM Bypass)", "cve")
+	add("certifried", "Certifried (CVE-2022-26923)", "adcs")
+	add("krbrelayup", "KrbRelayUp (RBCD self-relay)", "privilege_escalation")
+	add("machine_account_quota", "Machine Account Quota Abuse (MAQ=10)", "privilege_escalation")
+	add("mitm6", "MITM6 IPv6/DHCPv6 Poisoning", "network")
 }
 
 func addDomainTechniques(domains map[string]any, add techniqueAdd) {

--- a/cli/internal/scoreboard/verify_test.go
+++ b/cli/internal/scoreboard/verify_test.go
@@ -114,7 +114,7 @@ func TestAnswerKeyHasAllExpectedTechniques(t *testing.T) {
 	want := []string{
 		"asrep_roast", "kerberoast",
 		"adcs_esc1", "adcs_esc2", "adcs_esc3", "adcs_esc4", "adcs_esc6",
-		"adcs_esc7", "adcs_esc9", "adcs_esc11", "adcs_esc13", "adcs_esc15",
+		"adcs_esc7", "adcs_esc8", "adcs_esc9", "adcs_esc11", "adcs_esc13", "adcs_esc15",
 		"adcs_esc10_case1", "adcs_esc10_case2",
 		"golden_ticket-essos.local",
 		"golden_ticket-north.sevenkingdoms.local",
@@ -126,6 +126,8 @@ func TestAnswerKeyHasAllExpectedTechniques(t *testing.T) {
 		"acl_abuse", "cross_forest_trust", "child_to_parent",
 		"constrained_delegation", "unconstrained_delegation",
 		"seimpersonate",
+		"nopac", "printnightmare", "zerologon", "cve_2019_1040",
+		"certifried", "krbrelayup", "machine_account_quota", "mitm6",
 	}
 	for _, w := range want {
 		if !techIDs[w] {


### PR DESCRIPTION
**Key Changes:**

- Added support for ADCS ESC8, ESC5, and ESC14 techniques in scoreboard logic
- Implemented universal technique attribution for default lab vulnerabilities
- Updated tests and config to include new techniques and ensure coverage

**Added:**

- Universal technique attribution function - Added `addUniversalTechniques` to
  scoreboard generation, crediting lab-wide vulnerabilities such as noPac,
  PrintNightmare, ZeroLogon, Certifried, Machine Account Quota abuse, MITM6,
  and others, making them visible regardless of per-host markers
- New ADCS techniques - Included ADCS ESC5, ESC8, and ESC14 in the scoreboard
  label mapping for complete coverage of known ADCS escalation paths

**Changed:**

- Scoreboard extraction logic - Replaced hardcoded "child_to_parent"
  technique with call to `addUniversalTechniques` to generalize handling of
  lab-wide vulnerabilities
- Config updates - Added "adcs_esc8" to the list of applicable vulns in
  specific lab host configurations to reflect new technique coverage
- Test coverage - Extended expected answer keys in tests to include
  "adcs_esc8", noPac, PrintNightmare, ZeroLogon, Certifried, machine account
  quota, mitm6, and other universal techniques to match new logic

**Removed:**

- Direct addition of "child_to_parent" technique in extraction function,
  replaced by new universal handling logic