### PR TITLE
fix: harden Windows update reboot recovery and parameterize warpgate AMI regions

### DIFF
--- a/ansible/roles/settings_updates/README.md
+++ b/ansible/roles/settings_updates/README.md
@@ -19,8 +19,11 @@ Install Windows updates on managed hosts
 - **Prevent forced user registry unload (fixes WUA 0x800703FA)** (ansible.windows.win_regedit)
 - **Reset Windows Update components** (ansible.windows.win_shell)
 - **Reboot to clear pending registry operations** (ansible.windows.win_reboot)
+- **Ensure host recovered after reboot** (ansible.builtin.wait_for_connection)
 - **Enable update service** (ansible.windows.win_service)
 - **Install all updates and reboot as many times as needed** (ansible.windows.win_updates)
+- **Ensure host recovered after updates** (ansible.builtin.wait_for_connection)
+- **Fail if Windows updates did not complete** (ansible.builtin.assert)
 
 ## Example Playbook
 

--- a/ansible/roles/settings_updates/tasks/main.yml
+++ b/ansible/roles/settings_updates/tasks/main.yml
@@ -28,8 +28,16 @@
 
     - name: Reboot to clear pending registry operations
       ansible.windows.win_reboot:
-        reboot_timeout: 600
-        post_reboot_delay: 30
+        reboot_timeout: 1800
+        post_reboot_delay: 60
+      ignore_errors: true  # tolerate a wedged SSM poll; a genuinely dead box is caught below
+
+    - name: Ensure host recovered after reboot
+      # wait_for_connection re-attempts a downed connection; until/rescue do not
+      # retry on 'unreachable', so they cannot ride out a wedged SSM channel.
+      ansible.builtin.wait_for_connection:
+        timeout: 600
+        sleep: 20
 
     - name: Enable update service
       ansible.windows.win_service:
@@ -46,3 +54,19 @@
       retries: 5
       delay: 120
       until: update_result is not failed
+      ignore_errors: true  # let a wedged SSM poll fall through to recovery + assert below
+
+    - name: Ensure host recovered after updates
+      # win_updates performs its own internal reboots; a wedged SSM channel during
+      # one of them can exhaust the retries above. Re-attempt the connection before
+      # deciding the box is actually dead.
+      ansible.builtin.wait_for_connection:
+        timeout: 600
+        sleep: 20
+
+    - name: Fail if Windows updates did not complete
+      ansible.builtin.assert:
+        that: update_result is not failed
+        fail_msg: >-
+          Windows updates did not complete after {{ update_result.attempts | default('?') }}
+          attempt(s): {{ update_result.msg | default('unknown error') }}

--- a/warpgate-templates/goad-dc-base-2016/warpgate.yaml
+++ b/warpgate-templates/goad-dc-base-2016/warpgate.yaml
@@ -18,7 +18,7 @@ name: goad-dc-base-2016
 version: latest
 
 base:
-  image: "arn:aws:ssm:us-west-1::parameter/aws/service/ami-windows-latest/Windows_Server-2016-English-Full-Base"
+  image: "arn:aws:ssm:${aws_region}::parameter/aws/service/ami-windows-latest/Windows_Server-2016-English-Full-Base"
 
 variables:
   aws_region: us-west-1
@@ -41,7 +41,7 @@ targets:
     region: "${aws_region}"
     instance_type: "${instance_type}"
     ami_name: "goad-dc-base-2016-{{timestamp}}"
-    volume_size: 100
+    volume_size: 50
     ami_tags:
       Name: goad-dc-base-2016
       Lab: GOAD

--- a/warpgate-templates/goad-dc-base/warpgate.yaml
+++ b/warpgate-templates/goad-dc-base/warpgate.yaml
@@ -17,7 +17,7 @@ name: goad-dc-base
 version: latest
 
 base:
-  image: "arn:aws:ssm:us-west-1::parameter/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
+  image: "arn:aws:ssm:${aws_region}::parameter/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
 
 variables:
   aws_region: us-west-1
@@ -40,7 +40,7 @@ targets:
     region: "${aws_region}"
     instance_type: "${instance_type}"
     ami_name: "goad-dc-base-{{timestamp}}"
-    volume_size: 100
+    volume_size: 50
     ami_tags:
       Name: goad-dc-base
       Lab: GOAD

--- a/warpgate-templates/goad-mssql-base-2016/warpgate.yaml
+++ b/warpgate-templates/goad-mssql-base-2016/warpgate.yaml
@@ -18,7 +18,7 @@ name: goad-mssql-base-2016
 version: latest
 
 base:
-  image: "arn:aws:ssm:us-west-1::parameter/aws/service/ami-windows-latest/Windows_Server-2016-English-Full-Base"
+  image: "arn:aws:ssm:${aws_region}::parameter/aws/service/ami-windows-latest/Windows_Server-2016-English-Full-Base"
 
 variables:
   aws_region: us-west-1
@@ -48,7 +48,7 @@ targets:
     region: "${aws_region}"
     instance_type: "${instance_type}"
     ami_name: "goad-mssql-base-2016-{{timestamp}}"
-    volume_size: 100
+    volume_size: 50
     ami_tags:
       Name: goad-mssql-base-2016
       Lab: GOAD

--- a/warpgate-templates/goad-mssql-base/warpgate.yaml
+++ b/warpgate-templates/goad-mssql-base/warpgate.yaml
@@ -17,7 +17,7 @@ name: goad-mssql-base
 version: latest
 
 base:
-  image: "arn:aws:ssm:us-west-1::parameter/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
+  image: "arn:aws:ssm:${aws_region}::parameter/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
 
 variables:
   aws_region: us-west-1
@@ -47,7 +47,7 @@ targets:
     region: "${aws_region}"
     instance_type: "${instance_type}"
     ami_name: "goad-mssql-base-{{timestamp}}"
-    volume_size: 100
+    volume_size: 50
     ami_tags:
       Name: goad-mssql-base
       Lab: GOAD


### PR DESCRIPTION
**Key Changes:**

- Added connection recovery steps to survive wedged SSM channels during Windows update reboots
- Parameterized the AWS region in warpgate AMI source images to remove hardcoded regions
- Reduced warpgate base image volume sizes from 100GB to 50GB across all GOAD templates

**Added:**

- Connection recovery after reboots - Introduced `wait_for_connection` tasks after both the pending-operations reboot and the update install step in `settings_updates/tasks/main.yml`, since `wait_for_connection` re-attempts a downed connection whereas `until`/`rescue` cannot ride out a wedged SSM channel on 'unreachable'
- Explicit update completion check - Added an `assert` task that fails with a descriptive message (including attempt count and error) if Windows updates did not complete, ensuring a genuinely dead box is caught rather than silently passing

**Changed:**

- Reboot resilience tuning - Increased `reboot_timeout` to 1800 and `post_reboot_delay` to 60, and set `ignore_errors: true` on the reboot and update tasks so a wedged SSM poll falls through to the new recovery and assert logic instead of failing outright (`settings_updates/tasks/main.yml`)
- Region-agnostic AMI sources - Replaced hardcoded `us-west-1` in the SSM parameter ARN with the `${aws_region}` variable across all GOAD warpgate templates (`goad-dc-base`, `goad-dc-base-2016`, `goad-mssql-base`, `goad-mssql-base-2016`)
- Smaller base image volumes - Lowered `volume_size` from 100 to 50 for all GOAD warpgate build targets to reduce cost and build footprint
- Documentation updates - Updated `settings_updates/README.md` to reflect the new connection recovery and update assertion tasks in the task list