### PR TITLE
fix: resolve lab config through active environment for scoring

### DIFF
--- a/cli/cmd/score.go
+++ b/cli/cmd/score.go
@@ -49,7 +49,7 @@ func init() {
 	scoreCmd.Flags().String("ssh-key", "", "Path to SSH private key for the Kali VM (Azure; auto-discovered if omitted)")
 	scoreCmd.Flags().String("ssh-user", "kali", "SSH username for the Kali VM (Azure)")
 
-	scoreGenerateKeyCmd.Flags().String("config", "", "Path to GOAD config.json (default: ad/GOAD/data/config.json)")
+	scoreGenerateKeyCmd.Flags().String("config", "", "Path to GOAD config.json (default: the active environment's resolved lab config)")
 	scoreGenerateKeyCmd.Flags().String("output", "", "Output path for answer_key.json (default: scoreboard/answer_key.json)")
 }
 
@@ -238,7 +238,13 @@ func runScoreGenerateKey(cmd *cobra.Command, _ []string) error {
 	}
 	configPath, _ := cmd.Flags().GetString("config")
 	if configPath == "" {
-		configPath = filepath.Join(cfg.ProjectRoot, "ad", "GOAD", "data", "config.json")
+		// Resolve through the active environment so overlays and variant labs
+		// are honored. Hardcoding ad/GOAD/data/config.json scores the base lab
+		// no matter which --env is selected.
+		configPath, err = cfg.ResolvedLabConfigPath()
+		if err != nil {
+			return err
+		}
 	}
 	outputPath, _ := cmd.Flags().GetString("output")
 	if outputPath == "" {

--- a/cli/cmd/scoreboard.go
+++ b/cli/cmd/scoreboard.go
@@ -50,10 +50,10 @@ func init() {
 	scoreboardCmd.AddCommand(scoreboardRunCmd)
 	scoreboardCmd.AddCommand(scoreboardDemoCmd)
 
-	scoreboardGenerateKeyAlias.Flags().String("config", "", "Path to GOAD config.json (default: ad/GOAD/data/config.json)")
+	scoreboardGenerateKeyAlias.Flags().String("config", "", "Path to GOAD config.json (default: the active environment's resolved lab config)")
 	scoreboardGenerateKeyAlias.Flags().String("output", "", "Output path for answer_key.json (default: scoreboard/answer_key.json)")
 
-	scoreboardDemoCmd.Flags().String("config", "", "Path to GOAD config.json (default: ad/GOAD/data/config.json)")
+	scoreboardDemoCmd.Flags().String("config", "", "Path to GOAD config.json (default: the active environment's resolved lab config)")
 
 	scoreboardRunCmd.Flags().String("transport", "local", "Transport: local, ssm, or ares")
 	scoreboardRunCmd.Flags().String("report", "./report.jsonl", "Path to the agent's report file (on the target, for local/ssm)")
@@ -196,7 +196,13 @@ func runScoreboardDemo(cmd *cobra.Command, _ []string) error {
 	}
 	configPath, _ := cmd.Flags().GetString("config")
 	if configPath == "" {
-		configPath = filepath.Join(cfg.ProjectRoot, "ad", "GOAD", "data", "config.json")
+		// Resolve through the active environment so overlays and variant labs
+		// are honored. Hardcoding ad/GOAD/data/config.json scores the base lab
+		// no matter which --env is selected.
+		configPath, err = cfg.ResolvedLabConfigPath()
+		if err != nil {
+			return err
+		}
 	}
 	ak, err := scoreboard.GenerateAnswerKey(configPath)
 	if err != nil {


### PR DESCRIPTION
**Key Changes:**

- Scoring and scoreboard commands now honor the active environment when resolving the default GOAD config path
- Replaced hardcoded `ad/GOAD/data/config.json` path with `cfg.ResolvedLabConfigPath()` so overlays and variant labs are scored correctly
- Updated CLI flag help text to reflect the new environment-aware default

**Changed:**

- Default config resolution in `runScoreGenerateKey` - Replaced the hardcoded `ad/GOAD/data/config.json` fallback with `cfg.ResolvedLabConfigPath()`, ensuring the selected `--env`, overlays, and variant labs are honored instead of always scoring the base lab (`cli/cmd/score.go`)
- Default config resolution in `runScoreboardDemo` - Applied the same environment-aware resolution so demo scoring matches the active environment (`cli/cmd/scoreboard.go`)
- Flag help text - Updated the `--config` flag descriptions across the score generate-key, scoreboard generate-key alias, and scoreboard demo commands to describe the new default as "the active environment's resolved lab config" (`cli/cmd/score.go`, `cli/cmd/scoreboard.go`)