### PR TITLE
build: add Taskfile for build automation and installation

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  BINARY_NAME: dreadgoad
+  CMD_PATH: .
+
+includes:
+  go:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/go/Taskfile.yaml"
+    dir: ./cli
+    vars:
+      BINARY_NAME: '{{.BINARY_NAME}}'
+      CMD_PATH: '{{.CMD_PATH}}'
+  ansible:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/ansible/Taskfile.yaml"
+    dir: ./ansible
+
+tasks:
+  default:
+    desc: Build, test, and clean
+    cmds:
+      - task: go:default
+
+  install:
+    desc: Install the dreadgoad binary to GOPATH/bin
+    cmds:
+      - task: go:install

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,20 @@
 # DreadGOAD CLI Reference
 
+## Installation
+
+Install the `dreadgoad` binary to your `GOPATH/bin` using the project Taskfile:
+
+```bash
+task install
+```
+
+This runs `go install` from the `cli/` module and drops the binary in
+`$(go env GOPATH)/bin`. Ensure that directory is on your `PATH`, then run
+`dreadgoad --help` to confirm the install.
+
+Run `task --list` to see all available tasks. `task` (no arguments) builds,
+tests, and cleans the CLI.
+
 ## Commands
 
 Run `dreadgoad <command> --help` for full flag listings. Major commands:


### PR DESCRIPTION
**Key Changes:**

- Introduced a project-level Taskfile with Go and Ansible task template integrations
- Added an `install` task to build and install the `dreadgoad` binary to `GOPATH/bin`
- Documented the installation workflow in the CLI reference

**Added:**

- Build automation - Created `Taskfile.yaml` that includes shared Go and Ansible taskfile templates from CowDogMoo, with a `default` task for build/test/clean and an `install` task for installing the `dreadgoad` binary
- Installation documentation - Added an "Installation" section to `docs/cli.md` explaining how to use `task install`, verify the binary is on the `PATH`, and discover available tasks via `task --list`