### PR TITLE
Restore generic dreadgoad.yaml defaults

### DIFF
--- a/dreadgoad.yaml
+++ b/dreadgoad.yaml
@@ -1,12 +1,12 @@
 # DreadGOAD CLI Configuration
-env: dreadindex
-provider: azure  # Provider: aws, azure, proxmox, ludus
-region: centralus
+env: staging
+provider: aws  # Provider: aws, azure, proxmox, ludus
+# region: us-west-2  # Override provider region (default: from inventory)
 instance_profile: WarpgateImageBuilderInstanceProfile  # IAM instance profile for EC2 Image Builder
 debug: false
 max_retries: 3
 retry_delay: 30
-idle_timeout: 3600
+idle_timeout: 1200
 # log_dir: ~/.ansible/logs/goad
 # project_root: /path/to/DreadGOAD  # Auto-detected if omitted
 
@@ -51,22 +51,9 @@ environments:
     variant_name: variant-1
     vpc_cidr: "10.0.0.0/16"
   staging:
-    variant: true
-    variant_source: ad/GOAD
-    variant_target: ad/GOAD-dreadindex
-    variant_name: dreadindex
+    variant: false
     vpc_cidr: "10.1.0.0/16"
   prod:
     vpc_cidr: "10.2.0.0/16"
   test:
-    variant: true
-    variant_source: ad/GOAD
-    variant_target: ad/GOAD-dreadindex
-    variant_name: dreadindex
     vpc_cidr: "10.8.0.0/16"
-  dreadindex:
-    variant: true
-    variant_source: ad/GOAD
-    variant_target: ad/GOAD-dreadindex
-    variant_name: dreadindex
-    vpc_cidr: "10.1.0.0/16"

--- a/dreadgoad.yaml
+++ b/dreadgoad.yaml
@@ -1,7 +1,7 @@
 # DreadGOAD CLI Configuration
 env: staging
 provider: aws  # Provider: aws, azure, proxmox, ludus
-# region: us-west-2  # Override provider region (default: from inventory)
+# region: us-west-2  # Fallback when environments.<env>.region is unset; --region / DREADGOAD_REGION win
 instance_profile: WarpgateImageBuilderInstanceProfile  # IAM instance profile for EC2 Image Builder
 debug: false
 max_retries: 3

--- a/dreadgoad.yaml
+++ b/dreadgoad.yaml
@@ -2,7 +2,7 @@
 env: staging
 provider: aws  # Provider: aws, azure, proxmox, ludus
 # region: us-west-2  # Fallback when environments.<env>.region is unset; --region / DREADGOAD_REGION win
-instance_profile: WarpgateImageBuilderInstanceProfile  # IAM instance profile for EC2 Image Builder
+# instance_profile: MyImageBuilderInstanceProfile  # IAM instance profile for EC2 Image Builder; empty lets the build create one
 debug: false
 max_retries: 3
 retry_delay: 30


### PR DESCRIPTION
`dreadgoad.yaml` is the template every user starts from, but #344 committed a working copy from a one-off deployment. This reverts the deployment-specific values.

### Changed
- `env:` back to `staging`
- `provider:` back to `aws`; the hardcoded region is commented out again
- `idle_timeout: 3600` → `1200`

### Removed
- The bespoke per-deployment environment block
- Variant overrides (`variant`/`variant_source`/`variant_target`/`variant_name`) that #344 grafted onto the shared `staging` and `test` environments — `staging` is `variant: false` and `test` is CIDR-only again

### Fixed
Two pre-existing template bugs, both surfaced in review:
- `instance_profile` was hardcoded to `WarpgateImageBuilderInstanceProfile`, an IAM profile no Terraform in this repo creates. `ami build` stamps any non-empty value onto every AMI target (`ami.go:260-262`) and no warpgate template sets one itself, so a new user's build pointed at a profile absent from their account. Now commented out, restoring `viper.SetDefault("instance_profile", "")` — which is what makes the instance factory create its own profile (`iam.tf:37`).

